### PR TITLE
Extract date helper from internal project

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * This file is part of the deliberry/date package
+ * For full copyright and license information, please view the
+ *  LICENSE file that was distributed with this package.
+ * (c) 2016 Deliberry.com
+ */
+
+namespace Deliberry;
+
+use Deliberry\Date\DateException;
+use DateTimeImmutable;
+use SplStack;
+
+/**
+ * DateTime helper.
+ *
+ * Works with DateTimeImmutable instances.
+ */
+final class Date
+{
+    /**
+     * Create DateTimeImmutable from formatted string.
+     * Throws when errors or warnings in the process.
+     *
+     * @param string $formattedString Input string to convert.
+     * @param string $format Format of the given string.
+     *
+     * @return DateTimeImmutable
+     */
+    public static function fromFormattedString(string $formattedString, string $format): DateTimeImmutable
+    {
+        $date = DateTimeImmutable::createFromFormat("!{$format}", $formattedString);
+
+        $errors = DateTimeImmutable::getLastErrors();
+        if (!$date instanceof DateTimeImmutable || !empty($errors['warnings'])) {
+            throw DateException::invalidFormat($formattedString, $format);
+        }
+
+        return $date;
+    }
+
+    /**
+     * Same as `fromFormattedString` but allows empty input, which is converted to current time.
+     *
+     * @param null|string $formattedString Input string to convert. If empty, uses current time.
+     * @param string $format Format of the given string.
+     *
+     * @return DateTimeImmutable
+     */
+    public static function fromOptionalFormattedString(?string $formattedString, string $format): DateTimeImmutable
+    {
+        if (empty($formattedString)) {
+            $formattedString = self::now()->format($format);
+        }
+
+        return self::fromFormattedString($formattedString, $format);
+    }
+
+    /**
+     * Return current instant. Can be override by time freezes.
+     *
+     * @return DateTimeImmutable Current instant.
+     */
+    public static function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+
+    /**
+     * Return current datetime with a modifier.
+     *
+     * @param string $modifier Modifier to apply to current datetime.
+     *
+     * @return DateTimeImmutable New instant with modifier applied.
+     */
+    public static function at(string $modifier): DateTimeImmutable
+    {
+        return self::now()->modify($modifier);
+    }
+
+    /**
+     * Forbid public creation of instances of this class
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Date/DateException.php
+++ b/src/Date/DateException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the deliberry/date package
+ * For full copyright and license information, please view the
+ *  LICENSE file that was distributed with this package.
+ * (c) 2016 Deliberry.com
+ */
+
+namespace Deliberry\Date;
+
+use InvalidArgumentException;
+
+final class DateException extends InvalidArgumentException
+{
+    public static function invalidFormat(string $formattedString, string $format)
+    {
+        return new self(sprintf(
+            'Date must comply with format "%s" but "%s" given.',
+            $format,
+            $formattedString
+        ));
+    }
+}

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * This file is part of the deliberry/date package
+ * For full copyright and license information, please view the
+ *  LICENSE file that was distributed with this package.
+ * (c) 2016 Deliberry.com
+ */
+
+use Deliberry\Date;
+use PHPUnit\Framework\TestCase;
+
+final class DateTest extends TestCase
+{
+    const DELTA_EQUAL = 0.001;
+
+    public function test_creation_from_formatted_string()
+    {
+        $expected = (new DateTimeImmutable())->setDate(2017, 11, 28)->setTime(14, 5, 10);
+
+        $result = Date::fromFormattedString('2017-11-28 14:05:10', 'Y-m-d H:i:s');
+
+        self::assertDatesAreNear($expected, $result);
+    }
+
+    public function test_creation_from_incomplete_format()
+    {
+        $expected = (new DateTimeImmutable())->setDate(2017, 11, 1)->setTime(0, 0, 0);
+
+        $result = Date::fromFormattedString('2017-11', 'Y-m');
+
+        self::assertDatesAreNear($expected, $result);
+    }
+
+    public function test_creation_failed_from_empty_string()
+    {
+        self::expectException(Deliberry\Date\DateException::class);
+
+        Date::fromFormattedString('', 'U.u');
+    }
+
+    public function test_creation_failed_from_wrong_formatted_string()
+    {
+        self::expectException(Deliberry\Date\DateException::class);
+
+        Date::fromFormattedString('2017-01-08 04:05', 'Y-m-d H:i:s');
+    }
+
+    public function test_creation_failed_from_well_formatted_string_but_invalid_date()
+    {
+        self::expectException(Deliberry\Date\DateException::class);
+
+        Date::fromFormattedString('2017-01-35', 'Y-m-d');
+    }
+
+    public function test_creation_from_optional_string_with_empty_returns_current()
+    {
+        $expected = DateTimeImmutable::createFromFormat('U', time());
+
+        $instant = Date::fromOptionalFormattedString('', 'Y-m-d H:i:s');
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_creation_from_optional_string_with_null_returns_current()
+    {
+        $expected = new DateTimeImmutable('today 00:00');
+
+        $instant = Date::fromOptionalFormattedString(null, 'Y-m-d');
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_now_returns_current_instant()
+    {
+        $expected = new DateTimeImmutable();
+
+        $instant = Date::now();
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_at_allows_modification()
+    {
+        $expected = new DateTimeImmutable('8 minutes ago');
+
+        $instant = Date::at('8 minutes ago');
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_at_allows_fixed_modification()
+    {
+        $expected = new DateTimeImmutable('tomorrow 08:05');
+
+        $instant = Date::at('tomorrow 08:05');
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_dates_are_near_assertion_fails()
+    {
+        self::expectException(PHPUnit\Framework\ExpectationFailedException::class);
+        self::assertDatesAreNear(new DateTimeImmutable(), new DateTimeImmutable('+1 hour'));
+    }
+
+    private function assertDatesAreNear(DateTimeImmutable $lhs, DateTimeImmutable $rhs, float $delta = self::DELTA_EQUAL)
+    {
+        self::assertThat(
+            abs($lhs->format('U.u') - $rhs->format('U.u')),
+            self::lessThan($delta),
+            'Dates should be equal'
+        );
+    }
+}


### PR DESCRIPTION
Extract `Deliberry\Date` class to its own separate project.
This is more like a factory layer over `DateTimeImmutable` interface.

Public static methods:
- `now()`: returns current instant.
- `at($modifier)`: return the result of apply a modifier to the current instant.
- `fromFormattedString($formattedString, $format)`: hides internals of validation for transform formatted strings into instants.
- `fromOptionalFormattedString($optionalFormattedString, $format)`: empty values of formatted string are treated as if current instant is given.

[EDIT: Time freezing feature split into another PR]