### PR TITLE
Feature/time freeze

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,10 @@
     bootstrap = "lib/autoload.php"
     colors = "true"
 >
+    <listeners>
+        <listener class="Deliberry\Date\Listener\PHPUnit\FreezeTimeListener" />
+    </listeners>
+
     <testsuites>
         <testsuite name="deliberry/date">
             <directory>test</directory>

--- a/src/Date/Listener/PHPUnit/FreezeTimeListener.php
+++ b/src/Date/Listener/PHPUnit/FreezeTimeListener.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Deliberry\Date\Listener\PHPUnit;
+
+use DateTimeImmutable;
+use Deliberry\Date;
+use PHPUnit\Framework\BaseTestListener;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Allow PHPUnit tests to froze time of Deliberry\Date during execution through annotation.
+ * By default this annotation is `@freezeTime`, but can be configured at construction.
+ */
+final class FreezeTimeListener extends BaseTestListener
+{
+    public function __construct($annotationName = 'freezeTime')
+    {
+        $this->annotationName = $annotationName;
+    }
+
+    public function startTest(Test $test)
+    {
+        $this->isTimeFrozen = false;
+        if (!$test instanceof TestCase) {
+            return;
+        }
+
+        $annotations = $this->getAnnotations($test, $this->annotationName);
+        if (empty($annotations)) {
+            return;
+        }
+
+        // Only applies first annotation
+        foreach ($annotations as $timeModifier) {
+            $this->isTimeFrozen = true;
+            $this->freezeTime($timeModifier);
+            break;
+        }
+    }
+
+    public function endTest(Test $test, $time)
+    {
+        if ($this->isTimeFrozen) {
+            $this->unfreezeTime();
+        }
+    }
+
+    private function getAnnotations(TestCase $test, string $annotation)
+    {
+        $annotations = $test->getAnnotations();
+        foreach ([ 'method', 'class' ] as $context) {
+            if (isset($annotations[$context][$annotation])) {
+                return $annotations[$context][$annotation];
+            }
+        }
+
+        return false;
+    }
+
+    private function freezeTime(string $modifier)
+    {
+        Date::freezeTime(new DateTimeImmutable($modifier));
+    }
+
+    private function unfreezeTime()
+    {
+        Date::unfreezeTime();
+    }
+
+    private $annotationName;
+    private $isTimeFrozen = false;
+}

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -98,10 +98,135 @@ final class DateTest extends TestCase
         self::assertDatesAreNear($expected, $instant);
     }
 
+    public function test_freezes_time_for_now()
+    {
+        $expected = new DateTimeImmutable('yesterday 06:05');
+        Date::freezeTime($expected);
+
+        $instant = Date::now();
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+    public function test_freezes_time_for_at()
+    {
+        $expected = Date::at('today 06:15');
+        $frozenInstant = Date::at('yesterday 08:05');
+        Date::freezeTime($frozenInstant);
+
+        $instant = Date::at('tomorrow 06:15');
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_unfreezing_goes_back_to_normal()
+    {
+        $frozenInstant = new DateTimeImmutable('tomorrow 18:05');
+        Date::freezeTime($frozenInstant);
+
+        Date::unfreezeTime();
+
+        $expected = new DateTimeImmutable();
+        $instant = Date::now();
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_unfreeze_returns_last_frozen_time()
+    {
+        $expected = new DateTimeImmutable('today 18:05');
+        Date::freezeTime($expected);
+
+        $instant = Date::unfreezeTime();
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_allows_multiple_freezing()
+    {
+        Date::freezeTime(new DateTimeImmutable('tomorrow 18:05'));
+
+        $expected = new DateTimeImmutable('today 06:15');
+        Date::freezeTime($expected);
+
+        $instant = Date::now();
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_unfreeze_goes_back_to_previous_frozen_instant()
+    {
+        $expected = new DateTimeImmutable('tomorrow 18:05');
+        Date::freezeTime($expected);
+
+        Date::freezeTime(new DateTimeImmutable('today 06:15'));
+
+        Date::unfreezeTime();
+
+        $instant = Date::now();
+
+        self::assertDatesAreNear($expected, $instant);
+    }
+
+    public function test_time_is_initially_not_frozen()
+    {
+        self::assertFalse(Date::isTimeFrozen());
+    }
+
+    public function test_time_is_frozen_after_freezing()
+    {
+        Date::freezeTime(new DateTimeImmutable());
+
+        self::assertTrue(Date::isTimeFrozen());
+    }
+
+    public function test_time_is_not_frozen_after_calling_unfreeze()
+    {
+        Date::freezeTime(new DateTimeImmutable());
+        Date::unfreezeTime();
+
+        self::assertFalse(Date::isTimeFrozen());
+    }
+
+    public function test_time_is_frozen_after_multiple_freezing()
+    {
+        Date::freezeTime(new DateTimeImmutable());
+        Date::freezeTime(new DateTimeImmutable('tomorrow'));
+
+        self::assertTrue(Date::isTimeFrozen());
+    }
+
+    public function test_time_is_still_frozen_after_single_unfreeze_on_multiple_freezing()
+    {
+        Date::freezeTime(new DateTimeImmutable());
+        Date::freezeTime(new DateTimeImmutable('tomorrow'));
+        Date::unfreezeTime();
+
+        self::assertTrue(Date::isTimeFrozen());
+    }
+
+    public function test_time_is_not_frozen_after_calling_all_unfreezes()
+    {
+        Date::freezeTime(new DateTimeImmutable());
+        Date::freezeTime(new DateTimeImmutable('tomorrow'));
+        Date::unfreezeTime();
+        Date::unfreezeTime();
+
+        self::assertFalse(Date::isTimeFrozen());
+    }
+
     public function test_dates_are_near_assertion_fails()
     {
         self::expectException(PHPUnit\Framework\ExpectationFailedException::class);
         self::assertDatesAreNear(new DateTimeImmutable(), new DateTimeImmutable('+1 hour'));
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        while (Date::isTimeFrozen()) {
+            Date::unfreezeTime();
+        }
     }
 
     private function assertDatesAreNear(DateTimeImmutable $lhs, DateTimeImmutable $rhs, float $delta = self::DELTA_EQUAL)

--- a/test/FreezeTimeListenerTest.php
+++ b/test/FreezeTimeListenerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the deliberry/date package
+ * For full copyright and license information, please view the
+ *  LICENSE file that was distributed with this package.
+ * (c) 2016 Deliberry.com
+ */
+
+use Deliberry\Date;
+use PHPUnit\Framework\TestCase;
+
+final class FreezeTimeListenerTest extends TestCase
+{
+    /**
+     * @freezeTime
+     */
+    public function test_freezes_time()
+    {
+        $expected = Date::now();
+        $current = Date::now();
+
+        self::assertEquals($expected, $current);
+    }
+
+    /**
+     * @freezeTime yesterday 08:00
+     */
+    public function test_freezes_time_to_given_modifier()
+    {
+        $expected = new DateTimeImmutable('yesterday 08:00');
+        $current = Date::now();
+
+        self::assertEquals($expected, $current);
+    }
+}


### PR DESCRIPTION
Some internals are open to use in testing objects dependent of `Date`:
- `freezeTime($instant)`: Freezes time to a given instant. All requests to `now` and `at` are now relative to that instant. Multiple calls stack.
- `unfreezeTime()`: Removes last instant frozen with `freeze`. Throws if stack is empty.
- `isTimeFrozen()`: Returns if time is frozen.

Also a PHPUnit listener allows reacting to `@freezeTime` annotation for easier use.